### PR TITLE
Fix countfa variable names

### DIFF
--- a/src/countfa.c
+++ b/src/countfa.c
@@ -1,4 +1,4 @@
-#define GNUSOURCE
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
 #include <pthread.h>
@@ -10,7 +10,7 @@
 #define NUM_THREADS 4
 typedef struct {
     gzFile file;
-    size_t newline_count;
+    size_t seq_count;
     int thread_id;
 } ThreadData;
 pthread_mutex_t file_mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -46,7 +46,7 @@ void *count_newlines(void *arg) {
         }
     }
     pthread_mutex_lock(&count_mutex);
-    data->newline_count += local_count;
+    data->seq_count += local_count;
     pthread_mutex_unlock(&count_mutex);
     free(buffer);
     return NULL;
@@ -65,7 +65,7 @@ int main(int argc, char **argv) {
     ThreadData thread_data[NUM_THREADS];
     for (int i = 0; i < NUM_THREADS; i++) {
         thread_data[i].file = file;
-        thread_data[i].newline_count = 0;
+        thread_data[i].seq_count = 0;
         thread_data[i].thread_id = i;
         if (pthread_create(&threads[i], NULL, count_newlines, &thread_data[i]) != 0) {
             fprintf(stderr, "Error creating thread %d: %s\n", i, strerror(errno));
@@ -81,10 +81,10 @@ int main(int argc, char **argv) {
         fprintf(stderr, "An error occurred during processing. Results may be incomplete.\n");
         return 1;
     }
-    size_t total_newlines = 0;
+    size_t total_sequences = 0;
     for (int i = 0; i < NUM_THREADS; i++) {
-        total_newlines += thread_data[i].newline_count;
+        total_sequences += thread_data[i].seq_count;
     }
-    printf("Total sequences: %zu\n", total_newlines);
+    printf("Total sequences: %zu\n", total_sequences);
     return 0;
 }


### PR DESCRIPTION
## Summary
- enable GNU extensions in `countfa.c`
- rename `newline_count` variable to `seq_count`
- adjust accumulation logic and totals printing

## Testing
- `make`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_686d1cbe2a508330a020c7894b12973b