### PR TITLE
Fix memory leak when destroying queue

### DIFF
--- a/src/countfa.c
+++ b/src/countfa.c
@@ -42,6 +42,13 @@ static void queue_init(ChunkQueue *q) {
 }
 
 static void queue_destroy(ChunkQueue *q) {
+    Chunk *c = q->head;
+    while (c) {
+        Chunk *next = c->next;
+        free(c->data);
+        free(c);
+        c = next;
+    }
     pthread_mutex_destroy(&q->mutex);
     pthread_cond_destroy(&q->cond);
 }


### PR DESCRIPTION
## Summary
- free any remaining `Chunk` nodes before destroying queue synchronization objects

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_686d257cb86c8330820dad34d2da84bd